### PR TITLE
HexFormatter additional test

### DIFF
--- a/tests/Nmure/Encryptor/Tests/Formatter/HexFormatterTest.php
+++ b/tests/Nmure/Encryptor/Tests/Formatter/HexFormatterTest.php
@@ -8,23 +8,25 @@ class HexFormatterTest extends AbstractFormatterTest
 {
     /**
      * {@inheritdoc}
-     *
-     * Also converts the secret key from hex to binary.
-     */
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->secret = hex2bin($this->secret);
-    }
-
-    /**
-     * {@inheritdoc}
      */
     public function testFormat()
     {
         $expected = bin2hex(sprintf('%s%s', $this->iv, $this->data));
         $this->assertEquals($expected, $this->formatter->format($this->iv, $this->data));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Asserts that the HexFormatter is working with an hex key and with
+     * and hex key converted to a binary key.
+     */
+    public function testFormatterWithEncryptor()
+    {
+        parent::testFormatterWithEncryptor();
+
+        $this->secret = hex2bin($this->secret);
+        parent::testFormatterWithEncryptor();
     }
 
     /**


### PR DESCRIPTION
Asserting that the `HexFormatter` is working with an hex key and also with an hex key converted to a binary key.
