### PR TITLE
turnHexKeyToBin() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ it must just implement the [`FormatterInterface`](/src/Formatter/FormatterInterf
     - `public void disableAutoIvUpdate()` : disable the automatic IV update before each
     encryption process. The encryption will use the last set IV or generate one if
     no IV was set.
+    - `public void turnHexKeyToBin()` : turns the hex secret key into a binary key.
     - `public string getIv()` : returns the IV of the encryptor.
     - `public void setIv($iv)` : set the given IV to the encryptor.
     - `public void setFormatter(FormatterInterface $formatter = null)` : sets the given
@@ -203,8 +204,8 @@ you'll probably have to turn your secret key into a binary key :
 use Nmure\Encryptor\Encryptor;
 use Nmure\Encryptor\Formatter\HexFormatter;
 
-$key = hex2bin('452F93C1A737722D8B4ED8DD58766D99'); // turning the hex key to a binary key
-$encryptor = new Encyptor($key, 'AES-256-CBC');
+$encryptor = new Encyptor('452F93C1A737722D8B4ED8DD58766D99', 'AES-256-CBC');
+$encryptor->turnHexKeyToBin(); // turning the hex key to a binary key
 $encryptor->setFormatter(new HexFormatter());
 
 $encrypted = $encryptor->encrypt('plain text data');

--- a/src/Encryptor.php
+++ b/src/Encryptor.php
@@ -4,6 +4,7 @@ namespace Nmure\Encryptor;
 
 use Nmure\Encryptor\Formatter\FormatterInterface;
 use Nmure\Encryptor\Exception\DecryptException;
+use Nmure\Encryptor\Exception\InvalidSecretKeyException;
 
 final class Encryptor
 {
@@ -132,6 +133,18 @@ final class Encryptor
     public function disableAutoIvUpdate()
     {
         $this->autoIvUpdate = false;
+    }
+
+    /**
+     * Turns the secret hex key into a binary key.
+     */
+    public function turnHexKeyToBin()
+    {
+        if (!ctype_xdigit($this->secret)) {
+            throw new InvalidSecretKeyException(sprintf('The secret key "%s" is not a hex key', $this->secret));
+        }
+
+        $this->secret = hex2bin($this->secret);
     }
 
     /**

--- a/src/Exception/DecryptException.php
+++ b/src/Exception/DecryptException.php
@@ -2,6 +2,6 @@
 
 namespace Nmure\Encryptor\Exception;
 
-class DecryptException extends \Exception
+class DecryptException extends \Exception implements ExceptionInterface
 {
 }

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Nmure\Encryptor\Exception;
+
+interface ExceptionInterface
+{
+}

--- a/src/Exception/InvalidSecretKeyException.php
+++ b/src/Exception/InvalidSecretKeyException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Nmure\Encryptor\Exception;
+
+class InvalidSecretKeyException extends \Exception implements ExceptionInterface
+{
+}

--- a/src/Exception/ParsingException.php
+++ b/src/Exception/ParsingException.php
@@ -2,6 +2,6 @@
 
 namespace Nmure\Encryptor\Exception;
 
-class ParsingException extends \Exception
+class ParsingException extends \Exception implements ExceptionInterface
 {
 }

--- a/tests/Nmure/Encryptor/Tests/EncryptorTest.php
+++ b/tests/Nmure/Encryptor/Tests/EncryptorTest.php
@@ -124,6 +124,26 @@ class EncryptorTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($iv, $this->encryptor->generateIv());
     }
 
+    /**
+     * @expectedException Nmure\Encryptor\Exception\InvalidSecretKeyException
+     * @expectedExceptionMessage The secret key "UVWXYZ" is not a hex key
+     */
+    public function testTurnHexKeyToBinThrowsException()
+    {
+        $enc = new Encryptor('UVWXYZ', $this->cipher);
+        $enc->turnHexKeyToBin();
+    }
+
+    public function testTurnKexKeyToBin()
+    {
+        $enc = new Encryptor(hex2bin($this->secret), $this->cipher);
+        $this->encryptor->turnHexKeyToBin();
+        $this->encryptor->disableAutoIvUpdate();
+        $enc->disableAutoIvUpdate();
+        $enc->setIv($this->encryptor->generateIv());
+        $this->assertEquals($enc->encrypt($this->data), $this->encryptor->encrypt($this->data));
+    }
+
     private function getFormatterMock()
     {
         return $this->getMockBuilder('Nmure\Encryptor\Formatter\FormatterInterface')


### PR DESCRIPTION
Added a new method to the `Encryptor` class to turn the secret hex key to a binary key.

It allows to keep the key in a hex format to provide it to the encryptor, and then turning it into a binary format.
